### PR TITLE
Update RCTEventDispatcher.h to work with RN 0.42.x

### DIFF
--- a/StripeNative/StripeNativeManager.m
+++ b/StripeNative/StripeNativeManager.m
@@ -13,6 +13,7 @@
 #import "PaymentViewController.h"
 #import "StripeNativeManager.h"
 
+
 @import PassKit;
 
 NSString *const StripeNativeDomain = @"com.lockehart.lib.StripeNative";


### PR DESCRIPTION
To fix the build fail issue duplicate declaration, import React/RCTEventDispatcher.h